### PR TITLE
Bs task files 2 workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 Workflows for processing high-throughput sequencing data for variant discovery with GATK4 and related tools.
 
 ### processing-for-variant-discovery-gatk4 :
-The processing-for-variant-discovery-gatk4 WDL pipeline implements data pre-processing according to the GATK Best Practices.  
+The processing-for-variant-discovery-gatk4 WDL pipeline implements data pre-processing according to the [GATK Best Practices](https://gatk.broadinstitute.org/hc/en-us/articles/360035535912). The workflow takes as input an unmapped BAM list file (text file containing paths to unmapped bam files) to perform preprocessing tasks such as mapping, marking duplicates, and base recalibration. It produces a single BAM file and its index suitable for [variant discovery analysis](https://gatk.broadinstitute.org/hc/en-us/articles/360035535932-Germline-short-variant-discovery-SNPs-Indels-) using tools such as Haplotypecaller.
+
+- If you are starting with FASTQ files visit the [seq-format-conversion](https://github.com/gatk-workflows/seq-format-conversion) repository for worklfows to convert FASTQs to UBAMS.
+- The BAM outputs can be used to perform a varity of other annalysis like somatic short variant discovery, germline short variant discovery, or germline copy number variant discovery. Visit the GATK Best Practices documentation to determine what to do next with the BAM files. 
 
 #### Requirements/expectations:
 - Pair-end sequencing data in unmapped BAM (uBAM) format
@@ -26,8 +29,7 @@ The processing-for-variant-discovery-gatk4 WDL pipeline implements data pre-proc
 - Samtools 1.3.1 (using htslib 1.3.1)
 - Python 2.7
 - Cromwell version support 
-  - Successfully tested on v49 
-  - Does not work on versions < v23 due to output syntax
+  - Successfully tested on v52 
   
 ### Important Notes :
 - Runtime parameters are optimized for Broad's Google Cloud Platform implementation.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Workflows for processing high-throughput sequencing data for variant discovery w
 ### processing-for-variant-discovery-gatk4 :
 The processing-for-variant-discovery-gatk4 WDL pipeline implements data pre-processing according to the [GATK Best Practices](https://gatk.broadinstitute.org/hc/en-us/articles/360035535912). The workflow takes as input an unmapped BAM list file (text file containing paths to unmapped bam files) to perform preprocessing tasks such as mapping, marking duplicates, and base recalibration. It produces a single BAM file and its index suitable for [variant discovery analysis](https://gatk.broadinstitute.org/hc/en-us/articles/360035535932-Germline-short-variant-discovery-SNPs-Indels-) using tools such as Haplotypecaller.
 
-- If you are starting with FASTQ files visit the [seq-format-conversion](https://github.com/gatk-workflows/seq-format-conversion) repository for worklfows to convert FASTQs to unmapped BAMS.
-- The BAM output from processing-for-variant-discovery-gatk4 can be used to perform a varity of other annalysis like somatic short variant discovery, germline short variant discovery, or germline copy number variant discovery. Visit the GATK Best Practices documentation to determine what to do next with the BAM files. 
+- If you are starting with FASTQ files visit the [seq-format-conversion](https://github.com/gatk-workflows/seq-format-conversion) repository for workflows to convert FASTQs to unmapped BAMS.
+- The processing-for-variant-discovery-gatk4 provides quick and general processing for sequence data using the latest releases of GATK. If users are interested in a more elaborate version of this workflow with quality control tasks and routinely tested for validity (useful in production environments) then visit the [gatk4-genome-processing-pipeline](https://github.com/gatk-workflows/gatk4-genome-processing-pipeline) repository.
+- The BAM output from processing-for-variant-discovery-gatk4 can be used to perform a variety of other analysis like somatic short variant discovery, germline short variant discovery, or germline copy number variant discovery. Visit the GATK Best Practices documentation to determine what to do next with the BAM files.
 
 #### Requirements/expectations:
 - Pair-end sequencing data in unmapped BAM (uBAM) format

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Workflows for processing high-throughput sequencing data for variant discovery w
 ### processing-for-variant-discovery-gatk4 :
 The processing-for-variant-discovery-gatk4 WDL pipeline implements data pre-processing according to the [GATK Best Practices](https://gatk.broadinstitute.org/hc/en-us/articles/360035535912). The workflow takes as input an unmapped BAM list file (text file containing paths to unmapped bam files) to perform preprocessing tasks such as mapping, marking duplicates, and base recalibration. It produces a single BAM file and its index suitable for [variant discovery analysis](https://gatk.broadinstitute.org/hc/en-us/articles/360035535932-Germline-short-variant-discovery-SNPs-Indels-) using tools such as Haplotypecaller.
 
-- If you are starting with FASTQ files visit the [seq-format-conversion](https://github.com/gatk-workflows/seq-format-conversion) repository for worklfows to convert FASTQs to UBAMS.
-- The BAM outputs can be used to perform a varity of other annalysis like somatic short variant discovery, germline short variant discovery, or germline copy number variant discovery. Visit the GATK Best Practices documentation to determine what to do next with the BAM files. 
+- If you are starting with FASTQ files visit the [seq-format-conversion](https://github.com/gatk-workflows/seq-format-conversion) repository for worklfows to convert FASTQs to unmapped BAMS.
+- The BAM output from processing-for-variant-discovery-gatk4 can be used to perform a varity of other annalysis like somatic short variant discovery, germline short variant discovery, or germline copy number variant discovery. Visit the GATK Best Practices documentation to determine what to do next with the BAM files. 
 
 #### Requirements/expectations:
 - Pair-end sequencing data in unmapped BAM (uBAM) format

--- a/processing-for-variant-discovery-gatk4.wdl
+++ b/processing-for-variant-discovery-gatk4.wdl
@@ -48,7 +48,12 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
     File ref_fasta
     File ref_fasta_index
     File ref_dict
-
+    File? ref_alt
+    File ref_sa 
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_amb
     File dbSNP_vcf
     File dbSNP_vcf_index
     Array[File] known_indels_sites_VCFs
@@ -99,6 +104,12 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
         ref_dict = ref_dict,
+        ref_alt = ref_alt,
+        ref_sa = ref_sa,
+        ref_ann = ref_ann,
+        ref_bwt = ref_bwt,
+        ref_pac = ref_pac,
+        ref_amb = ref_amb,
         docker_image = gotc_docker,
         bwa_path = gotc_path,
         gotc_path = gotc_path,

--- a/processing-for-variant-discovery-gatk4.wdl
+++ b/processing-for-variant-discovery-gatk4.wdl
@@ -57,7 +57,7 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
     String bwa_commandline = "bwa mem -K 100000000 -p -v 3 -t 16 -Y $bash_ref_fasta"
     Int compression_level = 5
   
-    String gatk_docker = "broadinstitute/gatk:4.1.6.0"
+    String gatk_docker = "broadinstitute/gatk:4.1.8.1"
     String gatk_path = "/gatk/gatk"
     String gotc_docker = "broadinstitute/genomes-in-the-cloud:2.3.1-1512499786"
     String gotc_path = "/usr/gitc/"


### PR DESCRIPTION
Declared `SamToFastqAndBwaMem.ref_sa, SamToFastqAndBwaMem.ref_pac, SamToFastqAndBwaMem.ref_ann, SamToFastqAndBwaMem.ref_amb, SamToFastqAndBwaMem.ref_bw` in the workflow block inputs instead of the task inputs to allow users to import and run the workflow from another workflow. 