### PR TITLE
Fix .dockstore.yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,9 +1,10 @@
-
 version: 1.2
 workflows:
-   - name: processing-for-variant-discovery-gatk4
-     subclass: WDL
-     primaryDescriptorPath: /processing-for-variant-discovery-gatk4
-     testParameterFiles:
-     -  /processing-for-variant-discovery-gatk4.hg38.wgs.inputs.json
-     -  /processing-for-variant-discovery-gatk4.b37.wgs.inputs.json
+  - name: processing-for-variant-discovery-gatk4
+    subclass: WDL
+    primaryDescriptorPath: /processing-for-variant-discovery-gatk4.wdl
+    testParameterFiles:
+      - /processing-for-variant-discovery-gatk4.hg38.wgs.inputs.json
+      - /processing-for-variant-discovery-gatk4.b37.wgs.inputs.json
+    authors:
+      - name: Beri Shifaw


### PR DESCRIPTION
This entry is currently not displaying correctly on Dockstore, likely due to the lack of ".wdl" in descriptor file path, resulting in the WDL not being found:
* [2.1.1](https://dockstore.org/workflows/github.com/gatk-workflows/gatk4-data-processing/processing-for-variant-discovery-gatk4:2.1.1?tab=files)
* [Master](https://dockstore.org/workflows/github.com/gatk-workflows/gatk4-data-processing/processing-for-variant-discovery-gatk4:master?tab=files)

Older entries such as [2.1.0](https://dockstore.org/workflows/github.com/gatk-workflows/gatk4-data-processing/processing-for-variant-discovery-gatk4:2.1.0?tab=files) are still working.

This PR should fix the issue on master and any subsequent releases. The addition of the `authors` field and the spacing adjustments are not strictly required.